### PR TITLE
Add Hostelworld Terms of Service

### DIFF
--- a/declarations/Hostelworld.json
+++ b/declarations/Hostelworld.json
@@ -1,0 +1,8 @@
+{
+  "name": "Hostelworld",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://u.hwstatic.com/contracts/EN_April2018.pdf"
+    }
+  }
+}


### PR DESCRIPTION
This suggestion has been created with the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fsandbox-declarations&documentType=Terms%20of%20Service&name=Hostelworld&url=https%3A%2F%2Fu.hwstatic.com%2Fcontracts%2FEN_April2018.pdf&expertMode=true&expertMode=true) or [on your local instance](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fsandbox-declarations&documentType=Terms%20of%20Service&name=Hostelworld&url=https%3A%2F%2Fu.hwstatic.com%2Fcontracts%2FEN_April2018.pdf&expertMode=true&expertMode=true) if you have one set up.
  
Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, here are the things you should check:

- [ ] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [ ] **The service name matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).
- [ ] **The service ID (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).
- [ ] The document type is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [ ] **The selectors seem to be stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
- [ ] **The selectors are as simple as they can be**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class).
- [ ] **The document content is relevant**: it is not just a series of links, for example.
- [ ] **The generated version is readable**: it is complete and not mangled.
- [ ] **The generated version is clean**: it does not contain navigation links, unnecessary images, or extra content.

If there seems to be no appropriate document type for this document yet it is relevant to track for this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 👏💪
