### PR TITLE
Add Mailjet2 undefined

### DIFF
--- a/declarations/Mailjet2.json
+++ b/declarations/Mailjet2.json
@@ -4,7 +4,8 @@
     "undefined": {
       "fetch": "https://www.mailjet.com/privacy-policy/",
       "select": [
-        ".StyledDiv-sc-ajm81g-0"
+        ".StyledDiv-sc-ajm81g-0",
+        ".StyledDiv-sc-1tkx9jw-0"
       ]
     }
   }


### PR DESCRIPTION
### [🔎 Inspect this declaration suggestion](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fsandbox-declarations&json=%7B%22name%22%3A%22Mailjet2%22%2C%22documents%22%3A%7B%22undefined%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fwww.mailjet.com%2Fprivacy-policy%2F%22%2C%22select%22%3A%5B%22.StyledDiv-sc-ajm81g-0%22%5D%7D%7D%7D&expertMode=true)

- - -

Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:

- [ ] The suggested document **matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [ ] **The service name `Mailjet2` matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).
- [ ] **The service ID `Mailjet2` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).
- [ ] The document type `undefined` is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [ ] **Selectors are:**
  - **stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
  - **simple**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class or a tag).
- [ ] **Generated version** is:
  - **relevant**: it is not just a series of links, for example.
  - **readable**: it is complete and not mangled.
  - **clean**: it does not contain navigation links, unnecessary images, or extra content.

If no document type seems appropriate for this document yet it is relevant to track in this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪

- - -

_This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents.
You can load it [on your local instance](http://localhost:3000/en/service?destination=OpenTermsArchive%2Fsandbox-declarations&json=%7B%22name%22%3A%22Mailjet2%22%2C%22documents%22%3A%7B%22undefined%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fwww.mailjet.com%2Fprivacy-policy%2F%22%2C%22select%22%3A%5B%22.StyledDiv-sc-ajm81g-0%22%5D%7D%7D%7D&expertMode=true) if you have one set up._
