### PR TITLE
Upload Snapshots and Versions on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,12 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm run test:modified
+      - name: Generate artifacts
+        if: ${{ failure() }}
+        run: npm run track:modified
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: snapshots_and_versions
+          path: ./data
+          if-no-files-found: error


### PR DESCRIPTION
When a test is failing, it is sometimes interesting to be able to download the corresponding versions and snapshots to see what selector broke for example.

To be reviewed after #149 

You can have a look at the artifacts uploaded when an error occur on [this branch](https://github.com/OpenTermsArchive/sandbox-declarations/actions/runs/3434370768)